### PR TITLE
Add PHP port for shared hosting

### DIFF
--- a/php/Database.php
+++ b/php/Database.php
@@ -1,0 +1,18 @@
+<?php
+class Database {
+    private $pdo;
+    public function __construct() {
+        $dsn = getenv('DB_DSN') ?: 'mysql:host=localhost;dbname=tenderfinder;charset=utf8mb4';
+        $user = getenv('DB_USER') ?: 'root';
+        $pass = getenv('DB_PASS') ?: '';
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+        $this->pdo = new PDO($dsn, $user, $pass, $options);
+    }
+    public function pdo() {
+        return $this->pdo;
+    }
+}
+?>

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,22 @@
+# PHP Version of School Tender Finder
+
+This directory provides a lightweight PHP implementation of a few API endpoints from the original Node.js server. It is designed for deployment on shared hosting services such as Aruba that typically offer PHP and MySQL.
+
+## Requirements
+
+- PHP 8.0 or newer
+- MySQL (or MariaDB) database
+
+Environment variables used for database connection:
+
+- `DB_DSN` – e.g. `mysql:host=localhost;dbname=tenderfinder;charset=utf8mb4`
+- `DB_USER` – database user
+- `DB_PASS` – database password
+
+## Endpoints
+
+- `POST /api/schools` – upload a CSV file named `file` containing school data. Basic columns supported: `codiceMeccanografico`, `denominazioneScuola`, `indirizzoEmail`, `sitoWeb`.
+- `GET /api/schools` – fetch all schools.
+- `GET /api/tenders` – fetch all tenders.
+
+This is a simplified port and does not cover all features of the Node.js application, but it demonstrates how similar functionality can be implemented using PHP.

--- a/php/index.php
+++ b/php/index.php
@@ -1,0 +1,65 @@
+<?php
+require_once __DIR__ . '/Database.php';
+header('Content-Type: application/json');
+
+$db = new Database();
+$pdo = $db->pdo();
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$method = $_SERVER['REQUEST_METHOD'];
+
+function not_found() {
+    http_response_code(404);
+    echo json_encode(['message' => 'Not Found']);
+    exit;
+}
+
+// Simple routing
+if ($path === '/api/schools' && $method === 'POST') {
+    if (!isset($_FILES['file'])) {
+        http_response_code(400);
+        echo json_encode(['message' => 'No file uploaded']);
+        exit;
+    }
+
+    $handle = fopen($_FILES['file']['tmp_name'], 'r');
+    if (!$handle) {
+        http_response_code(400);
+        echo json_encode(['message' => 'Failed to read uploaded file']);
+        exit;
+    }
+
+    $headers = fgetcsv($handle);
+    $inserted = 0;
+    while (($row = fgetcsv($handle)) !== false) {
+        $data = array_combine($headers, $row);
+        if (!$data) continue;
+        $stmt = $pdo->prepare('INSERT INTO schools (codice_meccanografico, denominazione_scuola, indirizzo_email, sito_web) VALUES (:code, :name, :email, :web) ON DUPLICATE KEY UPDATE denominazione_scuola=VALUES(denominazione_scuola)');
+        $stmt->execute([
+            ':code' => $data['codiceMeccanografico'] ?? '',
+            ':name' => $data['denominazioneScuola'] ?? '',
+            ':email' => $data['indirizzoEmail'] ?? '',
+            ':web' => $data['sitoWeb'] ?? ''
+        ]);
+        $inserted++;
+    }
+    fclose($handle);
+    echo json_encode(['inserted' => $inserted]);
+    exit;
+}
+
+if ($path === '/api/schools' && $method === 'GET') {
+    $stmt = $pdo->query('SELECT * FROM schools');
+    $schools = $stmt->fetchAll();
+    echo json_encode($schools);
+    exit;
+}
+
+if ($path === '/api/tenders' && $method === 'GET') {
+    $stmt = $pdo->query('SELECT * FROM tenders ORDER BY created_at DESC');
+    echo json_encode($stmt->fetchAll());
+    exit;
+}
+
+not_found();
+?>


### PR DESCRIPTION
## Summary
- add a simple PHP server version for shared hosting environments
- include minimal database wrapper and example routes

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6855576223bc8324957ec194eb750c8e