### PR TITLE
Add MySQL schema for PHP version

### DIFF
--- a/php/Database.php
+++ b/php/Database.php
@@ -2,7 +2,7 @@
 class Database {
     private $pdo;
     public function __construct() {
-        $dsn = getenv('DB_DSN') ?: 'mysql:host=localhost;dbname=tenderfinder;charset=utf8mb4';
+        $dsn = getenv('DB_DSN') ?: 'mysql:host=localhost;dbname=school_finder;charset=utf8mb4';
         $user = getenv('DB_USER') ?: 'root';
         $pass = getenv('DB_PASS') ?: '';
         $options = [

--- a/php/README.md
+++ b/php/README.md
@@ -7,9 +7,9 @@ This directory provides a lightweight PHP implementation of selected API endpoin
 - PHP 8.0 or newer
 - MySQL (or MariaDB) database
 
-Environment variables used for database connection:
+Environment variables used for database connection (assuming MySQL via XAMPP on localhost):
 
-- `DB_DSN` – e.g. `mysql:host=localhost;dbname=tenderfinder;charset=utf8mb4`
+- `DB_DSN` – e.g. `mysql:host=localhost;dbname=school_finder;charset=utf8mb4`
 - `DB_USER` – database user
 - `DB_PASS` – database password
 

--- a/php/README.md
+++ b/php/README.md
@@ -1,6 +1,6 @@
 # PHP Version of School Tender Finder
 
-This directory provides a lightweight PHP implementation of a few API endpoints from the original Node.js server. It is designed for deployment on shared hosting services such as Aruba that typically offer PHP and MySQL.
+This directory provides a lightweight PHP implementation of selected API endpoints. It is designed for deployment on shared hosting services such as Aruba that typically offer PHP and MySQL.
 
 ## Requirements
 
@@ -29,4 +29,4 @@ mysql -u <user> -p <database> < schema.sql
 - `GET /api/schools` – fetch all schools.
 - `GET /api/tenders` – fetch all tenders.
 
-This is a simplified port and does not cover all features of the Node.js application, but it demonstrates how similar functionality can be implemented using PHP.
+This is a simplified version and does not cover all features of the original application, but it demonstrates how similar functionality can be implemented using PHP.

--- a/php/README.md
+++ b/php/README.md
@@ -13,6 +13,16 @@ Environment variables used for database connection:
 - `DB_USER` – database user
 - `DB_PASS` – database password
 
+### Database Initialization
+
+The file `schema.sql` in this directory contains the SQL statements to create
+the MySQL tables. Execute it once against your database before running the PHP
+endpoints:
+
+```bash
+mysql -u <user> -p <database> < schema.sql
+```
+
 ## Endpoints
 
 - `POST /api/schools` – upload a CSV file named `file` containing school data. Basic columns supported: `codiceMeccanografico`, `denominazioneScuola`, `indirizzoEmail`, `sitoWeb`.

--- a/php/schema.sql
+++ b/php/schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS schools (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    codice_meccanografico VARCHAR(255) NOT NULL UNIQUE,
+    denominazione_scuola VARCHAR(255) NOT NULL,
+    codice_istituto_riferimento VARCHAR(255),
+    denominazione_istituto_riferimento VARCHAR(255),
+    indirizzo_email VARCHAR(255),
+    sito_web VARCHAR(255),
+    indirizzo VARCHAR(255),
+    cap VARCHAR(10),
+    comune VARCHAR(255),
+    provincia VARCHAR(255),
+    regione VARCHAR(255),
+    area_geografica VARCHAR(255),
+    tipo_istituto VARCHAR(255),
+    detected_platforms JSON DEFAULT (JSON_ARRAY())
+);
+
+CREATE TABLE IF NOT EXISTS tenders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    school_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    excerpt TEXT,
+    deadline VARCHAR(255),
+    type VARCHAR(255) NOT NULL,
+    platform VARCHAR(255) NOT NULL,
+    pdf_url VARCHAR(255),
+    source_url VARCHAR(255),
+    hash VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (school_id) REFERENCES schools(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS scan_sessions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    status VARCHAR(255) NOT NULL DEFAULT 'pending',
+    total_schools INT NOT NULL,
+    completed_schools INT DEFAULT 0,
+    total_tenders INT DEFAULT 0,
+    started_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    completed_at TIMESTAMP NULL,
+    progress JSON DEFAULT (JSON_OBJECT())
+);


### PR DESCRIPTION
## Summary
- provide `schema.sql` with MySQL table definitions
- update PHP README with instructions to initialize MySQL database

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68555a13d37c8324aa4c84971df76e4e